### PR TITLE
Adjust the sentence to be simpler and concise.

### DIFF
--- a/quickstart/meet-the-workbook.mdx
+++ b/quickstart/meet-the-workbook.mdx
@@ -14,7 +14,7 @@ it's designed to allow your team and users to validate, correct, and import data
 
 In the next 15 minutes, you’ll design and configure a workbook 
 for your business. Once you’re finished you’ll be able to embed it in your application 
-as an import flow, or deploy a data collection portal.
+as an import flow.
 
 ### Using Schemas
 


### PR DESCRIPTION
I suggest changing this sentence:

Once you’re finished you’ll be able to embed it in your application as an import flow, or deploy a data collection portal.

To instead be:

Once you’re finished you’ll be able to embed it in your application as an import flow.

Because "embed it in your application as an import flow" to me is the same as saying "or deploy a data collection Portal", but to a non-Flatfiler, just saying "embed it in your application as an import flow" sounds very simple and clear. "data collection Portal" is an unclear statement.