### PR TITLE
Simplify code around secret key format

### DIFF
--- a/quickstart/meet-the-workbook.mdx
+++ b/quickstart/meet-the-workbook.mdx
@@ -45,7 +45,7 @@ Prerequisites: You'll need your [secret key](../security/authentication) to comp
 curl --request POST \
   --url https://platform.flatfile.com/api/v1/workbooks \
   --header 'Accept: application/json' \
-  --header 'Authorization: Bearer <secretKey>' \
+  --header 'Authorization: Bearer PASTE_SECRET_KEY_HERE' \
   --header 'Content-Type: application/json' \
   --data '{
   "name": "My First Workbook",


### PR DESCRIPTION
In the current code snippet inside the cURL in the docs, there is this line:

--header 'Authorization: Bearer <secretKey>' \

This makes it seem that secretKey must be inside the <>, which will actually return an error. To make this code piece more intuitive and less error prone to new developers, I suggest changing this to:

  --header 'Authorization: Bearer PASTE_SECRET_KEY_HERE' \