### PR TITLE
Add FYI messaging on pasting cURL command

### DIFF
--- a/quickstart/meet-the-workbook.mdx
+++ b/quickstart/meet-the-workbook.mdx
@@ -41,6 +41,8 @@ Prerequisites: You'll need your [secret key](../security/authentication) to comp
 1. Paste this cURL request to your terminal now to create a simple workbook or [run this command directly from our docs](https://flatfile.stoplight.io/docs/v10/branches/ashley-mulligan-sample-workbook/tjt005wdogklo-create-a-sample-workbook).
 2. Login and see the workbook you created in your [Dashboard](https://platform.flatfile.com) under Spaces.
 
+<FYI MESSAGE HERE, similar to "prerequisites pop-up above in the docs>
+
 ```shell Shell / cURL
 curl --request POST \
   --url https://platform.flatfile.com/api/v1/workbooks \


### PR DESCRIPTION
Something that gave me a hiccup was that when I clicked a button to copy the cURL command and pasted it to my IDE, I did not see the complete code of cURL command. This is because when I launch my IDE and open terminal, the terminal window is by default small, so it doesn't output the entire code if it is long.

I can see the full pasted code if I either drag the terminal window to become larger, or if I use the arrow up button on the keyboard to "scroll" up to see the beginning of the code. An FYI message like below is helpful:

"If your terminal doesn't show the entire code you copied from docs, either enlarge your terminal window or use arrow-up key on the keyboard to scroll to the beginning of the code"

Attaching the screenshot to show what I mean.
<img width="1798" alt="Screenshot 2023-04-24 at 1 18 24 PM" src="https://user-images.githubusercontent.com/61366150/234108236-0edaa0b9-4ec5-4052-b420-57133dfd99fd.png">