### PR TITLE
Small grammatical correction

### DIFF
--- a/quickstart/add-data-transformation.mdx
+++ b/quickstart/add-data-transformation.mdx
@@ -3,7 +3,7 @@ title: 2. Transform & validate data
 description: "Start validating and transforming data with a simple event handler in Flatfile."
 ---
 
-On the previous step, you created a workbook with a simple schema. Before continuing, head over to your [Dashboard](https://platform.flatfile.com) and:
+In the previous step, you created a workbook with a simple schema. Before continuing, head over to your [Dashboard](https://platform.flatfile.com) and:
 - Manually add a few sample records
 - Try exporting [this CSV file](https://docs.google.com/spreadsheets/d/1hhTv_T2kRE6tmhEAZEk9TuJI_6B1Zd9r1Pw7Q3hTxuA/edit#gid=0) and uploading it into your workbook
 


### PR DESCRIPTION
Instead of "On the previous step", it is grammatically correct to say "In the previous step"