### PR TITLE
Docs Feedback - blueprint explainer

### DIFF
--- a/blueprint/properties.mdx
+++ b/blueprint/properties.mdx
@@ -60,7 +60,7 @@ Defines a property that should be stored and read as either an integer or floati
 
 
 <ParamField path="config.decimal_places" default="0" type="number">
-  The number of decimal places to preserve accuracy to. Overages should be automatically rounded with a warning. A hook can pre-format to accomplish floor or ceil.
+  The number of decimal places to preserve accuracy to. Overages should be automatically rounded with a warning. A hook can pre-format to accomplish floor or ceiling.
 </ParamField>
 
 ```json
@@ -162,4 +162,4 @@ A `true` or `false` value type. Matching engines should attempt to resolve all c
 
 ## `date`
 
-Store a field as a GMT date. Data hooks must convert this value into a `YYYY-MM-DD` format in order for it to be considered a valid value. Datetime should be a separate and future supported value as it must consider timezone.
+Store a field as a GMT date. Data hooks must convert this value into a `YYYY-MM-DD` format in order for it to be considered a valid value. Datetime is not currently available, but will be a separately supported Field Type in the future, and will include timezone.


### PR DESCRIPTION
Under "reference" -
Readability-wise, this doesn't make sense to me: (I'm not sure how to re-word it, but would love something more clear or punctuated)
> Links should be established automatically by the matching engine or similar upon an evaluation of unique or similar columns between datasets.