### PR TITLE
make list punctuation consistent

### DIFF
--- a/blueprint/overview.mdx
+++ b/blueprint/overview.mdx
@@ -6,8 +6,8 @@ description: "Blueprint is a powerful DDL (Data Definition Language) created by 
 ## Terms
 
 - **Blueprint** — A collection of sheets that describe a complete dataset
-- **Sheet** — A collection of fields that describe a single entity (eg. a person, a product, a company).
-- **Field** — Describes an attribute of the entity (eg. name, email) and how it should behave.
+- **Sheet** — A collection of fields that describe a single entity (eg. a person, a product, a company)
+- **Field** — Describes an attribute of the entity (eg. name, email) and how it should behave
 
 
 <RequestExample>


### PR DESCRIPTION
Either all list items should have punctuation or none of them should. All the other lists I saw had no punctuation, so I'm removing the punctuation here