### PR TITLE
Update custom-actions.mdx

### DIFF
--- a/guides/custom-actions.mdx
+++ b/guides/custom-actions.mdx
@@ -13,7 +13,7 @@ Each workbook has built-in actions. In addition, you can attach a Custom Action 
 
 ![sheet.actions](../images/actions/sheet_actions.png)
 
-Once a user has extracted and mapped data into a <Tooltip tip="Learn more about Sheets">[Sheet](../concepts/workbooks#sheets-array)</Tooltip>, it may be better to run an operation on the entire data set, instead of making atomic transformations at the record- or cell-level. For example:
+Once a user has extracted and mapped data into a <Tooltip tip="Learn more about Sheets">[Sheet](../concepts/workbooks#sheets-array)</Tooltip>, it may be better to run an operation on the entire data set instead of making atomic transformations at the record- or cell-level. For example:
 * Sending a webhook that notifies your API of the data's readiness
 * Populating the Sheet with data from another source
 * Adding two different fields together after a user review's initial validation checks


### PR DESCRIPTION
An "action" here is defined slightly differently than in https://flatfileinc.mintlify.dev/docs/quickstart/submit-action where it's called a button. I mentioned in another PR that we should have an item under "Concepts" that defines the various action types so it can be linked.