### PR TITLE
Update guest_sidebar.mdx

### DIFF
--- a/guides/guest_sidebar.mdx
+++ b/guides/guest_sidebar.mdx
@@ -3,7 +3,7 @@ title: "Customize the guest sidebar"
 description: "Learn how to limit what Guests see in their Sidebar."
 ---
 
-<Info>This configuration only impacts Guests and not Admins. [Learn more about user access](../security/roles-and-permissions).</Info>
+<Info>This configuration only impacts Guests and not Admins. [Learn more about user access](../developer-tools/security/roles-and-permissions).</Info>
 
 Flatfile allows you to update your sidebar to hide/show certain elements via the <Tooltip tip="Learn more about Spaces">[Space](../concepts/spaces)</Tooltip> endpoint.
 

--- a/guides/guest_sidebar.mdx
+++ b/guides/guest_sidebar.mdx
@@ -3,7 +3,7 @@ title: "Customize the guest sidebar"
 description: "Learn how to limit what Guests see in their Sidebar."
 ---
 
-<Info>This configuration only impacts Guests, not Admins. [Learn more about user access](../security/roles-and-permissions).</Info>
+<Info>This configuration only impacts Guests and not Admins. [Learn more about user access](../security/roles-and-permissions).</Info>
 
 Flatfile allows you to update your sidebar to hide/show certain elements via the <Tooltip tip="Learn more about Spaces">[Space](../concepts/spaces)</Tooltip> endpoint.
 


### PR DESCRIPTION
1. The link to user roles and permissions is broken (takes you back to the overview). I assume we are going to define what Guest and Admin are in that link. 
2. Should the Guest sidebar show the Collaborators even in readonly? (looking at the image) 
3. My assumption is if `showGuestInvite=true', then they can invite  and will see the "Collaborators" without a readonly icon. But if `showGuestinvite=false`, both the ability to invite is disabled but also the "Collaborators" menu item is hidden.