### PR TITLE
Update meet-the-workbook.mdx

### DIFF
--- a/quickstart/meet-the-workbook.mdx
+++ b/quickstart/meet-the-workbook.mdx
@@ -43,6 +43,7 @@ Use your [secret key](../developer-tools/security/authentication#secret-and-publ
 
 <Tip>
 Use your [secret key](../developer-tools/security/authentication#secret-and-publishable-keys) from the `development` environment.
+ Secret key format is "sk_abcd..." and is found under "Getting Started" in your Flatfile dashboard.
 </Tip>
 
 ```shell Shell / cURL

--- a/quickstart/meet-the-workbook.mdx
+++ b/quickstart/meet-the-workbook.mdx
@@ -21,7 +21,7 @@ We'll begin by creating a new workbook using Flatfile's API. Paste this cURL req
 
 <Tip>
 Use your [secret key](../developer-tools/security/authentication#secret-and-publishable-keys) from the `development` environment.
- Secret key format is "sk_abcd..." and is found under "Getting Started" in your Flatfile dashboard.
+ Secret key format is "sk_abcd..." and is found in [your Flatfile Dashboard here](platform.flatfile.com/developers).
 </Tip>
 
 ```shell Shell / cURL


### PR DESCRIPTION
Adding additional text in the Tip box for 2 reasons:
- current Tip message explains to use "secret key", but not where to find it

- When generating API, the secret key also is called "Secret Key", so this can create confusion if a user uses an API secret key here instead. Adding the "sk_abcd..." format and where to find it helps avoid this confusion