### PR TITLE
Tiny typo fix

### DIFF
--- a/blueprint/field-types.mdx
+++ b/blueprint/field-types.mdx
@@ -88,7 +88,7 @@ Defines a reference to another sheet. Links should be established automatically 
 
 ## `enum`
 
-Defines an enumerated list of options for the user to select from. Matching tooling attempts to resolve incoming data assigment to a valid option. The maximum number of options for this list is `100`. For larger lists, users should use the `reference lookup types.
+Defines an enumerated list of options for the user to select from. Matching tooling attempts to resolve incoming data assigment to a valid option. The maximum number of options for this list is `100`. For larger lists, users should use the `reference` lookup types.
 
 
 <ParamField path="config.allow_custom" default="false" type="boolean">


### PR DESCRIPTION
Missing closing single quote for  `reference` in the last sentence in the Enum section