### PR TITLE
Update deploying.mdx

### DIFF
--- a/developer-tools/deploying.mdx
+++ b/developer-tools/deploying.mdx
@@ -25,12 +25,12 @@ While your own cloud provides the maximum level of control over listener code, q
 Once you have configured your workbook, you can deploy your workbook to your account at any time
 by opening the terminal in the root directory and entering this command:
 
-`npx flatfile deploy --token PASTE_SECRET_KEY_HERE`
+`npx flatfile@latest deploy --token=YOUR_SECRET_KEY`
 
 The CLI will give you prompts and updates as it's deploying:
 
 ``` terminal
-> npx flatfile@3.3.1 deploy --token sk_123456
+> npx flatfile@latest deploy --token=sk_123456
 
 ✔  Code package compiled to .flatfile/build.js
 ✔  Code package passed validation


### PR DESCRIPTION
Corrected an issue with the deploy command. It was missing the `@latest` after `npx flatfile`, and it was also missing a `=` after token. I also edited the command in the CLI code snippet to show that the example is consistent with the command we advise to use.

The correct command is found [in this documentation](https://flatfile.com/docs/quickstart/deploying)