### PR TITLE
Update field-types.mdx

### DIFF
--- a/blueprint/field-types.mdx
+++ b/blueprint/field-types.mdx
@@ -96,7 +96,8 @@ Defines an enumerated list of options for the user to select from. Matching tool
   "config": {
     "options": [
       {
-        "value": "active"
+        "value": "active",
+        "label": "Active"
       },
       {
         "value": "inactive",


### PR DESCRIPTION
A customer discovered today that if in the `enum` fields they do not provide "label", then even if they map "value" in matching the grid will show "undefined". 

Label must always be passed, and this code snippet suggest this can be omitted. Adding this to code snippet to make it more explicit

<img src="https://front.com/assets/img/favicons/favicon-32x32.png" height="16" width="16" alt="Front logo" /> [Front conversations](https://app.frontapp.com/open/top_arjrg)