### PR TITLE
Update part4.mdx

### DIFF
--- a/core-paths/part4.mdx
+++ b/core-paths/part4.mdx
@@ -140,7 +140,7 @@ import { FlatfileListener } from '@flatfile/listener'
 import { Flatfile, FlatfileClient } from '@flatfile/api'
 
 export const config: Pick<
-  Flatfile.WorkbookConfig,
+  Flatfile.CreateWorkbookConfig,
   'name' | 'sheets' | 'actions'
 > = {
   name: 'Employees workbook',


### PR DESCRIPTION
On Step 3 of the Embedded quickstart docs specify `CreateWorkbookConfig` and that works well in VS Code. I believe we just forgot to update here when we did the change from `WorkbookConfig`