### PR TITLE
fix: remove extra slash in Sheet-level access controls link

### DIFF
--- a/core-paths/collaborate.mdx
+++ b/core-paths/collaborate.mdx
@@ -22,7 +22,7 @@ Finally, you may want to create a onboarding project Space with a bespoke Bluepr
 
 You will want to create an <Tooltip tip="Isolated entities to create and test configurations">[Environment](../developer-tools/environment)</Tooltip> with `magic_link` authorization, which will allow members of your services team and your customers to invite others to a Flatfile Space created in that Environment. 
 You can also <Tooltip tip="Learn how to customize your Space">[Theme](../guides/theming)</Tooltip> your Space to match your brand's look and feel, creating a seamless experience for your customers. 
-Finally, you may also wish to control how members of the Space interact with Workbooks. This can be done via Workbook-specific <Tooltip tip="Guest permissions">[grants](../security/roles-and-permissions#guest-roles)</Tooltip>, as well as via setting <Tooltip tip="Restricting access to a sheet">[Sheet-level access controls](..//blueprint/access)</Tooltip>.
+Finally, you may also wish to control how members of the Space interact with Workbooks. This can be done via Workbook-specific <Tooltip tip="Guest permissions">[grants](../security/roles-and-permissions#guest-roles)</Tooltip>, as well as via setting <Tooltip tip="Restricting access to a sheet">[Sheet-level access controls](../blueprint/access)</Tooltip>.
 
 ### Launch onboarding projects
 


### PR DESCRIPTION
Removed extra slash before blueprint in `<a href="..//blueprint/access">Sheet-level access controls</a>`