### PR TITLE
fix:dxp-plugin typo

### DIFF
--- a/plugins/migrations/dxp-configure.mdx
+++ b/plugins/migrations/dxp-configure.mdx
@@ -5,14 +5,14 @@ icon: "download"
 ---
 
 <CardGroup cols={1}>
-  <Card title="@flatfile/plugin-record-hook" href="https://github.com/FlatFilers/flatfile-plugins/tree/main/plugins/record-hook" icon="github" >
-      *currently v0.0.4*
+  <Card title="@flatfile/plugin-dxp-configure" href="https://github.com/FlatFilers/flatfile-plugins/tree/main/plugins/dxp-configure" icon="github" >
+      *currently v0.0.5*
       <br/>
       **Author**<br/>
       David Boskovic<br/>
       <br/>
       **Last updated**<br/>
-      June 8, 2023
+      June 14, 2023
     </Card>
   </CardGroup>
 


### PR DESCRIPTION
Noticed a tiny disparity where the dxp plugin accidentally referenced record-hook and updated it.