### PR TITLE
Updated commit:created description

### DIFF
--- a/concepts/events.mdx
+++ b/concepts/events.mdx
@@ -167,8 +167,7 @@ outcome or plan subsequent actions accordingly.
 #### `commit:created`
 
 <ParamField path="commit:created" type="readonly">
-  Called when a new commit is created. For example, by creating or updating a
-  cell.
+  Commits are created when a cell in a Record (which is in a Sheet) is created or updated.
 </ParamField>
 
 ```json


### PR DESCRIPTION
Reference the underlying objects instead of a recursive description. There was previously no definition or description of a commit.