### PR TITLE
Update field-types.mdx

### DIFF
--- a/blueprint/field-types.mdx
+++ b/blueprint/field-types.mdx
@@ -63,7 +63,7 @@ Defines an enumerated list of options for the user to select from. Matching tool
   The value or ID of this option. This value will be sent in egress
 </ParamField>
 
-<ParamField path="label" default="value" type="string">
+<ParamField path="label" required type="string">
   A visual label for this option, defaults to value if not provided
 </ParamField>
 


### PR DESCRIPTION
Our docs don't specify it, but providing "label" is required. Otherwise, after matching all incoming labels to defined labels, in the grid they will all show "undefined". Label must always be present in the schema. 

Also removed "Default: value" from the docs, because I think this makes developers think that there is no need to provide "label".