### PR TITLE
Update guide.mdx

### DIFF
--- a/use-cases/embedding/javascript/guide.mdx
+++ b/use-cases/embedding/javascript/guide.mdx
@@ -488,7 +488,7 @@ Optionally, you can pass in additional properties on the Space as it's created.
 const flatfileOptions = {
     publishableKey,
     //additional props
-    spaceBody = {
+    spaceBody: {
       namespace: "Red",
     };
   }


### PR DESCRIPTION
It looks like the spaceBody and closeSpace parameters should set up with a colon, not equals sign. Update to reflect that 