### PR TITLE
fix: delimiter extractor example typo

### DIFF
--- a/plugins/extractors/delimiter-extractor.mdx
+++ b/plugins/extractors/delimiter-extractor.mdx
@@ -86,7 +86,7 @@ import { DelimiterExtractor } from "@flatfile/plugin-delimiter-extractor";
 ```
 
 ```js listener.js
-listener.use(DelimiterExtractor(".psv" { delimiter: "|" }));
+listener.use(DelimiterExtractor(".psv", { delimiter: "|" }));
 ```
 
 ### Full Example


### PR DESCRIPTION
Closes https://github.com/FlatFilers/flatfile-plugins/issues/187