### PR TITLE
Update guide.mdx

### DIFF
--- a/use-cases/embedding/react/guide.mdx
+++ b/use-cases/embedding/react/guide.mdx
@@ -230,8 +230,8 @@ When closing the Flatfile iframe, end users will see a dialog asking them if the
   --color-electric-800: #3b2fc9; //primary button color on hover
   --color-electric-700: #4c48ef; //primary button color
   --color-pigeon-600: #8b93a4; //text color
-  --color-pigeon-300: #d7dee8; // color of the border around secondary button
-  --color-pigeon-200: #e8edf4; //secondary button color
+  --color-pigeon-300: #d7dee8; //color of the border around secondary button
+  --color-pigeon-200: #e8edf4; //background color of secondary button on hover
   --color-text: var(--color-pigeon-primary); ////text title color
   --text-font: var(--brand-font-sans-serif);
   --size-base: 15px;


### PR DESCRIPTION
Suggesting a slight edit to inline comments of `--color-pigeon-200:`. The documentation currently says `secondary button color`. Actually, it is a color of the secondary button ONLY WHEN you hover over it, it is not a standing color that is always there. Therefore, updating the description. Suggesting this edit based on me testing on a pop up that appears when trying to close the importer on React.