### PR TITLE
Update guide.mdx

### DIFF
--- a/use-cases/embedding/react/guide.mdx
+++ b/use-cases/embedding/react/guide.mdx
@@ -227,12 +227,12 @@ When closing the Flatfile iframe, end users will see a dialog asking them if the
 }
 :root {
   --brand-font-sans-serif: "Helvetica", sans-serif;
-  --color-electric-800: #3b2fc9; //primary button color on hover
-  --color-electric-700: #4c48ef; //primary button color
-  --color-pigeon-600: #8b93a4; //text color
-  --color-pigeon-300: #d7dee8; // color of the border around secondary button
-  --color-pigeon-200: #e8edf4; //secondary button color
-  --color-text: var(--color-pigeon-primary); ////text title color
+  --color-electric-800: #3b2fc9; //primary button color on hover (confirmation pop up)
+  --color-electric-700: #4c48ef; //primary button color (confirmation pop up)
+  --color-pigeon-600: #8b93a4; //text color (confirmation pop up)
+  --color-pigeon-300: #d7dee8; // color of the border around secondary button (confirmation pop up)
+  --color-pigeon-200: #e8edf4; //secondary button color (confirmation pop up)
+  --color-text: var(--color-pigeon-primary); //header text color and secondary button text color (confirmation pop up)
   --text-font: var(--brand-font-sans-serif);
   --size-base: 15px;
 }


### PR DESCRIPTION
Adding slight changes to inline comments. `--color-text:` doesn't just control the color of the header text color on confirmation pop up, but also the text color inside the secondary button. Therefore, updating docs appropriately.

Also, so far, all thos changes inside `root` I see only appear on buttons and text inside confirmation pop up. Therefore, specifying that in the docs as well.