### PR TITLE
Update guide.mdx

### DIFF
--- a/guides/use-cases/embedding/javascript/guide.mdx
+++ b/guides/use-cases/embedding/javascript/guide.mdx
@@ -459,7 +459,7 @@ const flatfileOptions = {
     closeSpace: {
       operation: "contacts:submit",
       onClose: () => {},
-    };
+    }
   }
 ```
 
@@ -491,7 +491,7 @@ const flatfileOptions = {
     spaceBody: {
       name: "New Space"
       namespace: "Red",
-    };
+    }
   }
 ```
 

--- a/guides/use-cases/embedding/javascript/guide.mdx
+++ b/guides/use-cases/embedding/javascript/guide.mdx
@@ -489,8 +489,8 @@ const flatfileOptions = {
     publishableKey,
     //additional props, see Create Space endpoint for all the full list of properties (https://reference.flatfile.com/docs/api/25e20c8ab61c5-create-a-space)
     spaceBody: {
-      name: "New Space"
-      namespace: "Red",
+      name: "New Space",
+      namespace: "Red"
     }
   }
 ```


### PR DESCRIPTION
These semi-colons throw an error in the IDE/are bad syntax. Guessing we pulled from the definitions here as this is how it looks in the types but not in the implementation code