### PR TITLE
Update zip-extractor.mdx

### DIFF
--- a/plugins/extractors/zip-extractor.mdx
+++ b/plugins/extractors/zip-extractor.mdx
@@ -10,6 +10,10 @@ icon: "download"
   more](../../developer-tools/client_server_side#server-side-listeners)
 </Warning>
 
+<Warning>
+  For optimal performance of this plugin, please ensure you have "@flatfile/listener" version "0.3.15" or newer installed. Using this version or later helps prevent unexpected issues and guarantees full functionality.
+</Warning>
+
 <CardGroup cols={1}>
   <Card title="@flatfile/plugin-zip-extractor" icon="download">
     <br />


### PR DESCRIPTION
- incorporates a warning that this plug-in should be paired with at least "@flatfile/listener": "0.3.15".