### PR TITLE
update operation string to match job in step 4

### DIFF
--- a/quickstart/create-your-workbook.mdx
+++ b/quickstart/create-your-workbook.mdx
@@ -93,9 +93,9 @@ api: "POST https://platform.flatfile.com/api/v1/workbooks"
 <ParamField
   body="operation"
   type="string"
-  initialValue="submitAction"
-  default="submitAction"
-  placeholder="submitAction"
+  initialValue="submitActionFg"
+  default="submitActionFg"
+  placeholder="submitActionFg"
 >
   The name of the job operation
 </ParamField>
@@ -200,7 +200,7 @@ curl --request POST \
   ],
   "actions": [
     {
-      "operation": "submitAction",
+      "operation": "submitActionFg",
       "mode": "foreground",
       "label": "Submit",
       "description": "Submit data to webhook.site",


### PR DESCRIPTION
Hey Flatfile devs,

I'm currently upgrading our react codebase from Flatfile v2 -> v4, learning your product for the first time and working my way through the tutorials.

[Step 1](https://flatfile.com/docs/quickstart/create-your-workbook) of the beginner tutorial suggests creating a workbook with default operation of `submitAction` and [Step 4](https://flatfile.com/docs/quickstart/submit-action) looks for a job with string `"workbook:submitActionFg"` to configure.

I looked here in the docs and it looks like you suggest in [workbook_submit_pt1.mdx](https://github.com/FlatFilers/Guides/blob/main/_snippets/shared/workbook_submit_pt1.mdx) the workbook operation string should be `submitActionFg`

I've decided to submit this little PR to suggest updating the text in step 1 for more consistency to avoid tripping up future copy-pasters like myself
