### PR TITLE
feat: update create account link in top navbar

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -34,7 +34,7 @@
   "topbarLinks": [
     {
       "name": "Create account",
-      "url": "https://platform.flatfile.com/account/sign-up"
+      "url": "https://flatfile.com/account/sign-up/"
     }
   ],
   "topbarCtaButton": {


### PR DESCRIPTION
Updating the "Create Account" link to point to the [new account sign up page](https://flatfile.com/account/sign-up/) on the website