### PR TITLE
fix: rename localization guide and remove irrelevant section

### DIFF
--- a/guides/localization.mdx
+++ b/guides/localization.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Localization"
+title: "Translating your Space"
 description: "Translate and customize your Space with text overrides"
 icon: "language"
 ---
@@ -92,26 +92,6 @@ We support translations into these languages for now:
 | Spanish  | es     |
 
 <Tip>Need more languages? Reach out to us at [support@flatfile.io](mailto:support@flatfile.io).</Tip>
-
-### Adding Regional Dialects
-
-We automatically support regional dialects for every language supported above. 
-To ensure a seamless user experience, always include a base file for each language (e.g., 'en', 'es', 'fr'), which will serve as a fallback for users from regions not specified in your translations repository.
-
-Extend your customization by setting up directories for different dialects as illustrated below:
-
-
-```
-yourTranslationsDirectory/
-    └── locales/
-        ├── en/
-        │   └── translation.json
-        ├── en-US/
-        │   └── translation.json
-        ├── es/
-        │   └── translation.json
-        ...
-```
 
 ## Translating Your Custom Actions and Jobs
 


### PR DESCRIPTION
Renames the localization guide and removes regional support section as it is not working yet