### PR TITLE
Fix Bad Links for Actions Example Projects

### DIFF
--- a/concepts/actions.mdx
+++ b/concepts/actions.mdx
@@ -125,14 +125,14 @@ Find an Actions example in the Flatfile GitHub repository.
   <Card
     title="typescript"
     icon="code-merge"
-    href="https://github.com/FlatFilers/flatfile-docs-kitchen-sink/blob/main/typescript/actions/index.ts"
+    href="https://github.com/FlatFilers/flatfile-docs-kitchen-sink/blob/main/typescript/actions"
   >
     Clone the Actions example in Typescript
   </Card>
   <Card
     title="javascript"
     icon="js"
-    href="https://github.com/FlatFilers/flatfile-docs-kitchen-sink/blob/main/javascript/actions/index.js"
+    href="https://github.com/FlatFilers/flatfile-docs-kitchen-sink/blob/main/javascript/actions"
   >
     Clone the Actions example in Javascript
   </Card>


### PR DESCRIPTION
- The typescript and javascript example projects were linked to a file that no longer exists so it resulted in the user being linked to a 404