### PR TITLE
Fix iframe close button className

### DIFF
--- a/_snippets/shared/iframeStyles.mdx
+++ b/_snippets/shared/iframeStyles.mdx
@@ -69,11 +69,11 @@ body {
 }
 
 /* The close button in top right to close modal */
-/* .flatfile_displayAsModal .flatfile_close-button {
+/* .flatfile_displayAsModal .flatfile-close-button {
 } */
 
 /* The icon for the close button in top right to close modal */
-.flatfile_displayAsModal .flatfile_close-button svg {
+.flatfile_displayAsModal .flatfile-close-button svg {
   fill: var(--ff-secondary-color);
 }
 


### PR DESCRIPTION
A small update to correct the classname listed for the close button in one section of the docs. This update matches the className of the actual iframe close button, and matches the className as listed elsewhere in the documentation. 