### PR TITLE
Fix typo in localization.mdx

### DIFF
--- a/guides/localization.mdx
+++ b/guides/localization.mdx
@@ -28,7 +28,7 @@ We support translations into these languages:
 ## Adding translations
 ### Creating your translation files
 
-All our translation files are can be found in our [Platform-Translations repository](https://github.com/FlatFilers/Platform-Translations).
+All our translation files can be found in our [Platform-Translations repository](https://github.com/FlatFilers/Platform-Translations).
 You can fork the repo or simply copy paste the files in the repository to create your own translation files. 
 
 Simply update the values in each file with the text you would like to see.


### PR DESCRIPTION
fixing a 1-word typo on the localization page