### PR TITLE
Update example to be clearer, and work

### DIFF
--- a/upgrade/v2_upgrade.mdx
+++ b/upgrade/v2_upgrade.mdx
@@ -81,7 +81,9 @@ You'll be able to use this configuration object with the V2 Shims package to con
     ```
 
     ```js Platform JavaScript
-    import api from "@flatfile/api";
+    import { initializeFlatfile } from "@flatfile/javascript";
+    import { schemas } from "./schemas";
+    import { listener } from "../listeners/listener";
     import { configToBlueprint } from "@flatfile/v2-shims";
 
     const config = {
@@ -98,43 +100,27 @@ You'll be able to use this configuration object with the V2 Shims package to con
         ]
     }
 
-    export default function (listener) {
-        listener.filter({ job: "space:configure" }, (configure) => {
-            configure.on(
-                "job:ready",
-                async ({ context: { spaceId, environmentId, jobId } }) => {
-                    try {
-                        await api.jobs.ack(jobId, {
-                            info: "Gettin started.",
-                            progress: 10,
-                        });
-
-                        await api.workbooks.create({
-                            spaceId,
-                            environmentId,
-                            ...configToBlueprint(blueprint)
-                        });
-
-                        await api.jobs.complete(jobId, {
-                            outcome: {
-                                message: "Your Space was created.",
-                                acknowledge: true,
-                            },
-                        });
-                    } catch (error) {
-                        console.error("Error:", error.stack);
-
-                        await api.jobs.fail(jobId, {
-                            outcome: {
-                                message: "Creating a Space encountered an error. See Event Logs.",
-                                acknowledge: true,
-                            },
-                        });
-                    }
-                }
+    window.openFlatfile = ({publishableKey, environmentId}) => {
+        if (!publishableKey && !environmentId) {
+            throw new Error(
+                "You must provide a publishable key and an environment ID - pass through in index.html"
             );
-        })
-    }
+        }
+    
+        const flatfileOptions = {
+            publishableKey,
+            environmentId,
+            name: 'Contact Space',
+            workbook: configToBlueprint(config),
+            listener,
+            sidebarConfig: {
+                showSidebar: false,
+            },
+            // Additional props...
+        };
+    
+        initializeFlatfile(flatfileOptions);
+    };
     ```
 
     ```jsx Portal 2 React


### PR DESCRIPTION
The original example didn't work, and was a bit disconnected from the example repo. So I've updated it to be clearer, by fixing a var name typo and using code straight from the example repo. 

This seems to be clearer for customers migrating from v2