### PR TITLE
fix typo

### DIFF
--- a/developer-tools/environment.mdx
+++ b/developer-tools/environment.mdx
@@ -27,7 +27,7 @@ Your `publishableKey` and `secretKey` are specific to an environment therefore t
 
 1. Open Settings
 2. Click to Personal Tokens
-3. You can use the key pair in there to create an environment like:
+3. You can use the key pair in there to create an access token like:
 
 ```bash
 curl -X POST https://api.x.flatfile.com/v1/auth -H 'Content-Type: application/json' -d '{"clientId":"1234-1234", "secret":"1234-1234"}'


### PR DESCRIPTION
the client id and secret are used to create an access token which can then be used to create an environment