### PR TITLE
Typo in the code in upgrade docs

### DIFF
--- a/upgrade/v2_upgrade.mdx
+++ b/upgrade/v2_upgrade.mdx
@@ -232,7 +232,7 @@ If you're transitioning from a V2 Record Hook to a Platform Record Hook in your 
                 info: [
                     {
                         message: 'No last name provided so welcome to the Rock fam.',
-                        leval: 'warning'
+                        level: 'warning'
                     }
                 ]
             }


### PR DESCRIPTION
Typo in the code changes `leval` to `level`