### PR TITLE
fix: typo

### DIFF
--- a/orchestration/jobs.mdx
+++ b/orchestration/jobs.mdx
@@ -325,7 +325,7 @@ await api.jobs.ack(jobId, {
 
 ### Jobs.Update
 
-Once a Job is acknowledged, you can begin running your custom operation. Jobs were designed to handle large procesing loads, but you can easily update your user by updating the Job with a progress value.
+Once a Job is acknowledged, you can begin running your custom operation. Jobs were designed to handle large processing loads, but you can easily update your user by updating the Job with a progress value.
 
 ```jsx javascript
 await api.jobs.update(jobId, {


### PR DESCRIPTION
Fix typo `procesing` -> `processing`