### PR TITLE
Clarify date formatting

### DIFF
--- a/changelog/sdks/plugins/highlights.mdx
+++ b/changelog/sdks/plugins/highlights.mdx
@@ -433,7 +433,7 @@ icon: "plug"
       - Truthy values: '1', 'yes', 'true', 'on', ' ', 'y', and 1.
       - Falsy values: '- ', '0', 'no', 'false', 'off', ' ', 'n', 0, -1.
 
-    - **Dates:** Date strings and numbers are cast to a UTC string.
+    - **Dates:** Date strings and numbers are cast to a UTC string (note: `YYYY-MM-DD...` is interpreted as an ISO 8601 date and is treated as treated as UTC, while other formats are treated as local time and converted to UTC).
       - '2023-08-16' => 'Wed, 16 Aug 2023 00:00:00 GMT'
       - '08-16-2023' => 'Wed, 16 Aug 2023 00:00:00 GMT'
       - '08/16/2023' => 'Wed, 16 Aug 2023 00:00:00 GMT'

--- a/plugins-docs/transform/autocast.mdx
+++ b/plugins-docs/transform/autocast.mdx
@@ -73,7 +73,7 @@ are interpreted as numbers.
 
 ### Dates
 
-Date strings and numbers are cast to a UTC string. These are example of dates that will be cast:
+Date strings and numbers are cast to a UTC string. These are example of dates that will be cast (note: `YYYY-MM-DD...` is interpreted as an ISO 8601 date and is treated as treated as UTC, while other formats are treated as local time and converted to UTC):
 
 - `'2023-08-16'` => `'Wed, 16 Aug 2023 00:00:00 GMT'`
 - `'08-16-2023'` => `'Wed, 16 Aug 2023 00:00:00 GMT'`


### PR DESCRIPTION
The autocast plugin uses the Javascript `Date` constructor which interprets `2023-08-16` as an ISO 8601 date and `08-16-2023` to not be an ISO 8601 format. When a date string is in the ISO 8601 format (YYYY-MM-DD), it is treated as UTC (Coordinated Universal Time). Therefore, creating a new Date object with this string will interpret the date as midnight UTC of the specified date. `08-16-2023` is not in the ISO 8601 format and as such is interpreted as a non-ISO date strings in local time.