### PR TITLE
feat: Replace Deprecated upload:completed Event

### DIFF
--- a/_snippets/guides/documents/document-actions.mdx
+++ b/_snippets/guides/documents/document-actions.mdx
@@ -4,7 +4,7 @@
 import api from "@flatfile/api";
 
 export default function flatfileEventListener(listener) {
-  listener.on("upload:completed", async ({ context: { spaceId, fileId } }) => {
+  listener.on("file:created", async ({ context: { spaceId, fileId } }) => {
     const fileName = (await api.files.get(fileId)).data.name;
     const bodyText = `# Welcome
     ### Say hello to your first customer Space in the new Flatfile!
@@ -37,7 +37,7 @@ import { FlatfileEvent, FlatfileListener } from "@flatfile/listener";
 
 export default function flatfileEventListener(listener: FlatfileListener) {
   listener.on(
-    "upload:completed",
+    "file:created",
     async ({ context: { spaceId, fileId } }: FlatfileEvent) => {
       const fileName = (await api.files.get(fileId)).data.name;
       const bodyText = `# Welcome

--- a/_snippets/guides/guest_sidebar/block1.mdx
+++ b/_snippets/guides/guest_sidebar/block1.mdx
@@ -4,7 +4,7 @@ import api from "@flatfile/api";
 
 export default function flatfileEventListener(listener) {
   listener.on(
-    "upload:completed",
+    "file:created",
     async ({ context: { spaceId } }) => {
       try {
         const updateSpace = await api.spaces.update(spaceId, {
@@ -31,7 +31,7 @@ import { FlatfileEvent, FlatfileListener } from "@flatfile/listener";
 
 export default function flatfileEventListener(listener: FlatfileListener) {
   listener.on(
-    "upload:completed",
+    "file:created",
     async ({ context: { spaceId } }: FlatfileEvent) => {
       try {
         const updateSpace = await api.spaces.update(spaceId, {


### PR DESCRIPTION
- Replaces references of the deprecated upload:completed event with the newer file:created event; The events have the same exact body, so no other changes should be needed