### PR TITLE
Minor fix for icon color in light mode

### DIFF
--- a/custom.css
+++ b/custom.css
@@ -576,3 +576,15 @@ html:not(.dark) .bg-tooltip {
 .text-gray-600.dark\:text-white\/70 {
   color: white;
 }
+
+.rounded-md.bg-gray-100 {
+  color: white;
+}
+
+button.absolute.left-6.top-1\/2 svg {
+  color: white;
+}
+
+html:is(.dark) button.absolute.left-6.top-1\/2 svg {
+  color: black;
+}


### PR DESCRIPTION
Fixing black boxes where icons should render:

<img width="696" alt="Screenshot 2024-06-25 at 8 07 22 AM" src="https://github.com/FlatFilers/Guides/assets/11151764/4e34cd4b-d06e-4445-9eef-e3c311a06458">
