### PR TITLE
Remove FlatfileClient from JS docs

### DIFF
--- a/_snippets/shared/embedded_listener.mdx
+++ b/_snippets/shared/embedded_listener.mdx
@@ -166,14 +166,9 @@ Finally, let's get the data out of our system and to your destination.
 Once you add this code, when the submit button is clicked, this will be the place you can egress your data. Learn more about [Egress Out](../../guides/egress)
 
 ```tsx src/simple.js
-import { FlatfileClient } from "@flatfile/api";
+import api from "@flatfile/api";
 import { FlatfileListener } from "@flatfile/listener";
 import { recordHook } from "@flatfile/plugin-record-hook";
-
-const flatfile = new FlatfileClient({
-  token: process.env.FLATFILE_API_KEY,
-  environment: process.env.BASE_URL + "/v1",
-});
 
 export const listener = FlatfileListener.create((listener) => {
   listener.on("**", (event) => {
@@ -194,7 +189,7 @@ export const listener = FlatfileListener.create((listener) => {
     { job: "workbook:submitActionFg" },
     async ({ context: { jobId } }) => {
       try {
-        await flatfile.jobs.ack(jobId, {
+        await api.jobs.ack(jobId, {
           info: "Getting started.",
           // "progress" value must be a whole integer
           progress: 10,
@@ -203,7 +198,7 @@ export const listener = FlatfileListener.create((listener) => {
         // Make changes after cells in a Sheet have been updated
         console.log("Make changes here when an action is clicked");
 
-        await flatfile.jobs.complete(jobId, {
+        await api.jobs.complete(jobId, {
           outcome: {
             acknowledge: true,
             message: "This is now complete.",
@@ -215,7 +210,7 @@ export const listener = FlatfileListener.create((listener) => {
       } catch (error) {
         console.error("Error:", error.stack);
 
-        await flatfile.jobs.fail(jobId, {
+        await api.jobs.fail(jobId, {
           outcome: {
             message: "This job encountered an error.",
           },


### PR DESCRIPTION
We showed how to set up a FlatfileClient for api requests, but this isn't necessary for client-side listeners and was confusing customers who don't want to expose their secret key (necessary for a new FlatfileClient) client-side. 