### PR TITLE
Pass required space properties to OpenEmbed

### DIFF
--- a/documentation/sdks/angular/new_space.mdx
+++ b/documentation/sdks/angular/new_space.mdx
@@ -54,7 +54,7 @@ export class AppComponent {
   constructor(private spaceService: SpaceService) {}
 
   toggleSpace() {
-    this.spaceService.OpenEmbed();
+    this.spaceService.OpenEmbed(this.spaceProps);
     this.showSpace = !this.showSpace;
   }
 


### PR DESCRIPTION
`OpenEmbed()` requires the space properties to be passed in